### PR TITLE
Update composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
     "license": "proprietary",
     "require": {
         "php": ">=7.3",
-        "spryker/algolia": "^1.0.0",
+        "spryker/algolia": "*",
         "spryker/kernel": "^3.30.0",
         "spryker/locale": "^3.0.0",
         "spryker/money": "^2.8.0",


### PR DESCRIPTION
## PR Description

`spryker/algolia` is locked to ^1.0.0 but doesn't have proper semantic versioning. Since this package isn't really maintained you could either set a 1.0 release for `spryker/algolia` or accept this (temp-fix) PR to get the `search-algolia` module working at all.

## Checklist
- [x] I agree with the Code Contribution License Agreement in CONTRIBUTING.md
